### PR TITLE
stops ignoring log_output variable

### DIFF
--- a/lib/money_talks/adyen_client.rb
+++ b/lib/money_talks/adyen_client.rb
@@ -9,7 +9,7 @@ module MoneyTalks
         wsdl: wsdl,
         convert_request_keys_to: :lower_camelcase,
         pretty_print_xml: MoneyTalks::dev?,
-        log: true
+        log: log_output
         )
     end
 


### PR DESCRIPTION
on testing environment, I'd rather not have this log mixed with my report.
