### PR TITLE
Looses contraints on savon

### DIFF
--- a/lib/money_talks/version.rb
+++ b/lib/money_talks/version.rb
@@ -1,3 +1,3 @@
 module MoneyTalks
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/money_talks.gemspec
+++ b/money_talks.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.require_paths = ['lib']
 
- # gem.add_dependency 'savon', '= 2.3.2'
-  gem.add_dependency  'savon', '~> 2.10.0'
+  gem.add_dependency  'savon', '~> 2.10'
   gem.add_dependency 'activesupport'
 
   gem.add_development_dependency 'pry'


### PR DESCRIPTION
There are no breaking changes between savon 2.10
and 2.11 per the CHANGELOG.md so loosing 
contraints a little bit to accommodate rails 5
